### PR TITLE
Protobuf Repackaging

### DIFF
--- a/applications/json-translator/src/main/scala/com/hashmapinc/tempus/edge/jsonTranslator/iofog/IofogController.scala
+++ b/applications/json-translator/src/main/scala/com/hashmapinc/tempus/edge/jsonTranslator/iofog/IofogController.scala
@@ -7,8 +7,7 @@ import com.iotracks.elements.IOMessage
 import com.typesafe.scalalogging.Logger
 import scalapb.json4s.JsonFormat
 
-import com.hashmapinc.tempus.edge.proto.{MessageProtocols, ConfigMessageTypes, DataMessageTypes, JsonDataMessage}
-import com.hashmapinc.tempus.edge.track.proto.{TrackConfig, TrackMetadata, MqttConfig, OpcConfig}
+import com.hashmapinc.tempus.edge.proto._
 
 /**
  * This object holds the logic for handling iofog events

--- a/applications/json-translator/src/test/scala/com/hashmapinc/tempus/edge/jsonTranslator/iofog/IofogControllerTest.scala
+++ b/applications/json-translator/src/test/scala/com/hashmapinc/tempus/edge/jsonTranslator/iofog/IofogControllerTest.scala
@@ -6,7 +6,6 @@ import javax.json.Json
 import org.scalatest.FlatSpec
 
 import com.hashmapinc.tempus.edge.proto._
-import com.hashmapinc.tempus.edge.track.proto._
 
 class IofogControllerTest extends FlatSpec {
   // create sample protobuf objects from pb files

--- a/applications/opc-client/src/main/scala/com/hashmapinc/tempus/edge/opcClient/Config.scala
+++ b/applications/opc-client/src/main/scala/com/hashmapinc/tempus/edge/opcClient/Config.scala
@@ -5,7 +5,7 @@ import scala.util.Try
 
 import com.typesafe.scalalogging.Logger
 
-import com.hashmapinc.tempus.edge.track.proto.{TrackConfig, OpcConfig}
+import com.hashmapinc.tempus.edge.proto.{TrackConfig, OpcConfig}
 
 /**
  * This object is responsible for holding and updating local configurations

--- a/applications/opc-tag-filter/src/main/scala/com/hashmapinc/tempus/edge/opcTagFilter/Config.scala
+++ b/applications/opc-tag-filter/src/main/scala/com/hashmapinc/tempus/edge/opcTagFilter/Config.scala
@@ -5,7 +5,7 @@ import scala.util.Try
 
 import com.typesafe.scalalogging.Logger
 
-import com.hashmapinc.tempus.edge.track.proto.{TrackConfig, OpcConfig}
+import com.hashmapinc.tempus.edge.proto.{TrackConfig, OpcConfig}
 
 /**
  * This object is responsible for holding and updating local configurations

--- a/applications/opc-tag-filter/src/main/scala/com/hashmapinc/tempus/edge/opcTagFilter/opc/OpcConnection.scala
+++ b/applications/opc-tag-filter/src/main/scala/com/hashmapinc/tempus/edge/opcTagFilter/opc/OpcConnection.scala
@@ -15,7 +15,7 @@ import org.eclipse.milo.opcua.stack.client.UaTcpStackClient
 import com.typesafe.scalalogging.Logger
 
 import com.hashmapinc.tempus.edge.opcTagFilter.Config
-import com.hashmapinc.tempus.edge.track.proto.OpcConfig
+import com.hashmapinc.tempus.edge.proto.OpcConfig
 
 object OpcConnection {
   private val logger = Logger(getClass())

--- a/applications/opc-tag-filter/src/main/scala/com/hashmapinc/tempus/edge/opcTagFilter/opc/OpcController.scala
+++ b/applications/opc-tag-filter/src/main/scala/com/hashmapinc/tempus/edge/opcTagFilter/opc/OpcController.scala
@@ -6,9 +6,7 @@ import scala.util.matching.Regex
 import com.typesafe.scalalogging.Logger
 import org.eclipse.milo.opcua.sdk.client.OpcUaClient
 
-import com.hashmapinc.tempus.edge.proto.MessageProtocols
-import com.hashmapinc.tempus.edge.proto.ConfigMessageTypes
-import com.hashmapinc.tempus.edge.track.proto.OpcConfig
+import com.hashmapinc.tempus.edge.proto.{MessageProtocols, ConfigMessageTypes, OpcConfig}
 import com.hashmapinc.tempus.edge.opcTagFilter.Config
 import com.hashmapinc.tempus.edge.opcTagFilter.iofog.IofogConnection
 

--- a/applications/opc-tag-filter/src/test/scala/com/hashmapinc/tempus/edge/opcTagFilter/ConfigTest.scala
+++ b/applications/opc-tag-filter/src/test/scala/com/hashmapinc/tempus/edge/opcTagFilter/ConfigTest.scala
@@ -4,7 +4,7 @@ import java.nio.file.{Files, Paths}
 
 import org.scalatest.FlatSpec
 
-import com.hashmapinc.tempus.edge.track.proto.TrackConfig
+import com.hashmapinc.tempus.edge.proto.TrackConfig
 
 class ConfigTest extends FlatSpec {
   //===========================================================================

--- a/applications/track-manager/src/main/scala/com/hashmapinc/tempus/edge/track/manager/iofog/IofogController.scala
+++ b/applications/track-manager/src/main/scala/com/hashmapinc/tempus/edge/track/manager/iofog/IofogController.scala
@@ -9,8 +9,7 @@ import com.typesafe.scalalogging.Logger
 import com.google.protobuf.InvalidProtocolBufferException
 import scalapb.json4s.JsonFormat
 
-import com.hashmapinc.tempus.edge.proto.{MessageProtocols, ConfigMessageTypes}
-import com.hashmapinc.tempus.edge.track.proto.{TrackConfig, TrackMetadata, MqttConfig, OpcConfig}
+import com.hashmapinc.tempus.edge.proto._
 
 /**
  * This object holds the logic for handling iofog events

--- a/applications/track-manager/src/main/scala/com/hashmapinc/tempus/edge/track/manager/iofog/IofogListener.scala
+++ b/applications/track-manager/src/main/scala/com/hashmapinc/tempus/edge/track/manager/iofog/IofogListener.scala
@@ -6,8 +6,7 @@ import com.iotracks.api.listener.IOFogAPIListener
 import com.iotracks.elements.IOMessage
 import com.typesafe.scalalogging.Logger
 
-import com.hashmapinc.tempus.edge.proto.{MessageProtocols, ConfigMessageTypes}
-import com.hashmapinc.tempus.edge.track.proto.TrackConfig
+import com.hashmapinc.tempus.edge.proto.{MessageProtocols, ConfigMessageTypes, TrackConfig}
 
 /**
  * This object dispatches IoFog events to the IofogController

--- a/applications/track-manager/src/test/scala/com/hashmapinc/tempus/edge/track/manager/iofog/IofogControllerTest.scala
+++ b/applications/track-manager/src/test/scala/com/hashmapinc/tempus/edge/track/manager/iofog/IofogControllerTest.scala
@@ -7,8 +7,7 @@ import org.scalatest.FlatSpec
 import scalapb.json4s.JsonFormat
 
 import com.hashmapinc.tempus.edge.proto._
-import com.hashmapinc.tempus.edge.track.proto._
-import com.hashmapinc.tempus.edge.track.proto.TrackConfig._
+import com.hashmapinc.tempus.edge.TrackConfig._
 
 class IofogControllerTest extends FlatSpec {
   //===========================================================================

--- a/applications/track-manager/src/test/scala/com/hashmapinc/tempus/edge/track/manager/iofog/IofogControllerTest.scala
+++ b/applications/track-manager/src/test/scala/com/hashmapinc/tempus/edge/track/manager/iofog/IofogControllerTest.scala
@@ -7,7 +7,7 @@ import org.scalatest.FlatSpec
 import scalapb.json4s.JsonFormat
 
 import com.hashmapinc.tempus.edge.proto._
-import com.hashmapinc.tempus.edge.TrackConfig._
+import com.hashmapinc.tempus.edge.proto.TrackConfig._
 
 class IofogControllerTest extends FlatSpec {
   //===========================================================================

--- a/protobuf-definitions/src/main/protobuf/MqttConfig.proto
+++ b/protobuf-definitions/src/main/protobuf/MqttConfig.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package com.hashmapinc.tempus.edge.track.proto;
+package com.hashmapinc.tempus.edge.proto;
 
 // Define the configuration needed to work with MQTT services.
 message MqttConfig {

--- a/protobuf-definitions/src/main/protobuf/OpcConfig.proto
+++ b/protobuf-definitions/src/main/protobuf/OpcConfig.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package com.hashmapinc.tempus.edge.track.proto;
+package com.hashmapinc.tempus.edge.proto;
 
 // Define the configuration needed to work with OPC services.
 message OpcConfig {

--- a/protobuf-definitions/src/main/protobuf/TrackConfig.proto
+++ b/protobuf-definitions/src/main/protobuf/TrackConfig.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package com.hashmapinc.tempus.edge.track.proto;
+package com.hashmapinc.tempus.edge.proto;
 
 import "TrackMetadata.proto";
 import "MqttConfig.proto";

--- a/protobuf-definitions/src/main/protobuf/TrackMetadata.proto
+++ b/protobuf-definitions/src/main/protobuf/TrackMetadata.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package com.hashmapinc.tempus.edge.track.proto;
+package com.hashmapinc.tempus.edge.proto;
 
 message TrackMetadata {
   string track_name = 1; // track name.


### PR DESCRIPTION
This PR requests move all com.hashmapinc.tempus.edge.track.proto packaged pb defs into com.hashmapinc.tempus.edge.proto. 

It also fixes all importing throughout impacted edge applications.