### PR TITLE
Recursive Tag Filtering from User Regex in opc-tag-filter

### DIFF
--- a/applications/opc-tag-filter/src/main/scala/com/hashmapinc/tempus/edge/opcTagFilter/Driver.scala
+++ b/applications/opc-tag-filter/src/main/scala/com/hashmapinc/tempus/edge/opcTagFilter/Driver.scala
@@ -2,7 +2,8 @@ package com.hashmapinc.tempus.edge.opcTagFilter
 
 import com.typesafe.scalalogging.Logger
 
-import com.hashmapinc.tempus.edge.opcTagFilter.iofog.{IofogConnection, IofogController}
+import com.hashmapinc.tempus.edge.opcTagFilter.iofog.IofogConnection
+import com.hashmapinc.tempus.edge.opcTagFilter.opc.OpcConnection
 
 /**
  * Driver for the overall edge application
@@ -21,6 +22,7 @@ object Driver {
     log.info("CONTAINERID = " + Config.CONTAINER_ID)
 
     Config.updateConfigs
+    OpcConnection.updateClient
     
     log.info("Connecting to iofog...")
     IofogConnection.connect

--- a/applications/opc-tag-filter/src/main/scala/com/hashmapinc/tempus/edge/opcTagFilter/iofog/IofogController.scala
+++ b/applications/opc-tag-filter/src/main/scala/com/hashmapinc/tempus/edge/opcTagFilter/iofog/IofogController.scala
@@ -20,7 +20,6 @@ object IofogController {
    *
    * @param messages - list of received messages
    */
-  @Override
   def onMessages(
     messages: java.util.List[IOMessage]
   ): Unit = {

--- a/applications/opc-tag-filter/src/main/scala/com/hashmapinc/tempus/edge/opcTagFilter/opc/OpcController.scala
+++ b/applications/opc-tag-filter/src/main/scala/com/hashmapinc/tempus/edge/opcTagFilter/opc/OpcController.scala
@@ -82,7 +82,10 @@ object OpcController {
 
           // check for match
           currentMatches // TODO: append tag if curNode is a match
-        }).getOrElse(currentMatches)
+        }).recover({
+          case e: Exception => log.error("Error while traversing opc heirarchy: " + e)
+          currentMatches
+        }).get
         
         // recurse
         recurseTags(nodeQueue, updatedMatches)
@@ -109,6 +112,7 @@ object OpcController {
       val whitelistRegex = tagFilters.whitelist.mkString("|").r
       val blacklistRegex = tagFilters.blacklist.mkString("|").r
       OpcConnection.synchronized {
+        OpcConnection.client.get.connect.get // synchronous connection
         createSubscriptions(whitelistRegex, blacklistRegex, OpcConnection.client.get)
       }
     })

--- a/applications/opc-tag-filter/src/main/scala/com/hashmapinc/tempus/edge/opcTagFilter/opc/OpcController.scala
+++ b/applications/opc-tag-filter/src/main/scala/com/hashmapinc/tempus/edge/opcTagFilter/opc/OpcController.scala
@@ -118,7 +118,7 @@ object OpcController {
       // concat regex strings with '|' separator and create single regex for each tagFilter
       val tagFilters = Config.trackConfig.get.getOpcConfig.getTagFilters
       val whitelistRegex = tagFilters.whitelist.mkString("|").r
-      val blacklistRegex = tagFilters.blacklist.mkString("|").r
+      val blacklistRegex = (".*\\.\\_.*" +: tagFilters.blacklist).mkString("|").r // add regex to filter out any system tags
       OpcConnection.synchronized {
         createSubscriptions(whitelistRegex, blacklistRegex, OpcConnection.client.get)
       }


### PR DESCRIPTION
This PR includes the logic required in the opc-tag-filter to search an OPC server for tags that match a whitelist and do not match a blacklist of regular expressions.