### PR TITLE
Implemented device mapping in opc-tag-filter

### DIFF
--- a/applications/opc-tag-filter/src/main/scala/com/hashmapinc/tempus/edge/opcTagFilter/Driver.scala
+++ b/applications/opc-tag-filter/src/main/scala/com/hashmapinc/tempus/edge/opcTagFilter/Driver.scala
@@ -3,7 +3,7 @@ package com.hashmapinc.tempus.edge.opcTagFilter
 import com.typesafe.scalalogging.Logger
 
 import com.hashmapinc.tempus.edge.opcTagFilter.iofog.IofogConnection
-import com.hashmapinc.tempus.edge.opcTagFilter.opc.OpcConnection
+import com.hashmapinc.tempus.edge.opcTagFilter.opc.{OpcConnection, OpcController}
 
 /**
  * Driver for the overall edge application
@@ -21,9 +21,10 @@ object Driver {
     log.info("SELFNAME = " + System.getenv("SELFNAME"))
     log.info("CONTAINERID = " + Config.CONTAINER_ID)
 
-    Config.updateConfigs
-    OpcConnection.updateClient
-    
+    Config.updateConfigs                // load initial configs.
+    OpcConnection.updateClient          // init client connection.
+    OpcController.updateSubscriptions   // look for subscriptions.
+      
     log.info("Connecting to iofog...")
     IofogConnection.connect
     log.info("iofog connection was successful. Listening...")

--- a/applications/opc-tag-filter/src/main/scala/com/hashmapinc/tempus/edge/opcTagFilter/opc/OpcController.scala
+++ b/applications/opc-tag-filter/src/main/scala/com/hashmapinc/tempus/edge/opcTagFilter/opc/OpcController.scala
@@ -120,7 +120,11 @@ object OpcController {
       val whitelistRegex = tagFilters.whitelist.mkString("|").r
       val blacklistRegex = (".*\\.\\_.*" +: tagFilters.blacklist).mkString("|").r // add regex to filter out any system tags
       OpcConnection.synchronized {
-        createSubscriptions(whitelistRegex, blacklistRegex, OpcConnection.client.get)
+        try 
+          createSubscriptions(whitelistRegex, blacklistRegex, OpcConnection.client.get) 
+        catch {
+          case e: Exception => createSubscriptions(whitelistRegex, blacklistRegex, OpcConnection.client.get)
+        }
       }
     })
 

--- a/applications/opc-tag-filter/src/main/scala/com/hashmapinc/tempus/edge/opcTagFilter/opc/OpcController.scala
+++ b/applications/opc-tag-filter/src/main/scala/com/hashmapinc/tempus/edge/opcTagFilter/opc/OpcController.scala
@@ -27,16 +27,25 @@ object OpcController {
   private val configProtocol = MessageProtocols.CONFIG.value.toByte
   private val subscriptionsSubmission = ConfigMessageTypes.OPC_SUBSCRIPTIONS_SUBMISSION.value.toByte
 
-  /** This function recurses through the OPC server and finds matching tags
+  /** This function returns the first deviceName that tag matches the pattern of.
    *
-   *  @param whitelist - Regex that tags must match to be a subscription
-   *  @param opcClient  - milo OPC UA client to use for finding tags.
-   *  @param currentNode  - NodeId currently being evaluated for matches
-   *  @param currentMatches  - list of matches recursively found so far
+   *  @param tag - string value to check for matches
+   *  @param deviceMaps  - OpcConfig.DeviceMaps object for mapping string matches to device names
    *
-   *  @return matches - string array containing matching tags
+   *  @return deviceName - string value of the matching deviceName 
    */
-  
+  def getDeviceName(
+    tag: String,
+    deviceMaps: Seq[OpcConfig.DeviceMap]
+  ): String = {
+    // get all matching device names
+    val deviceName = deviceMaps.flatMap(dMap => {
+      if (dMap.pattern.r.findFirstIn(tag).isDefined) Option(dMap.device) else None
+    })
+
+    // return "" if no match found, otherwise return first match
+    if (deviceName.isEmpty) "" else deviceName(0)
+  }
 
   /** This function creates subscriptions from given regexs and opc client
    *
@@ -101,9 +110,12 @@ object OpcController {
     val matches: List[String] = recurseTags(Queue(Identifiers.RootFolder), List())
     val tags = if (blacklist.toString.isEmpty) matches else matches.filter(blacklist.findFirstIn(_).isEmpty)
 
-    // TODO: actually populate this with a toDevice method
+    // create subs
+    val deviceMaps = Config.trackConfig.get.getOpcConfig.deviceMaps
     OpcConfig.Subscriptions(
-      tags.map(tag => OpcConfig.Subscriptions.Subscription(tag, tag)) // should be (tag, toDevice(tag))
+      tags.map(tag => 
+        OpcConfig.Subscriptions.Subscription(tag, getDeviceName(tag, deviceMaps))
+      )
     )
   }
 


### PR DESCRIPTION
This PR contains logic to map tag values to device names based on opcConfig regex values.