### PR TITLE
Implement user-defined opc root node in opc-tag-filter BFS regex matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Standard message formatting should be used by all edge applications. The purpose
 - maintain flexibility for future edge application requirements
 - improve the ease of application debugging
 
-### Message Protocol
+## Message Protocols
 Each IoFog message should contain a `messageProtocol` byte that describes the kind of message being sent. This value is a `byte` or `uint8` depending on the language. It is the **first byte** in the messageContent field of the IoFog message. The significance of each value is detailed below:
 
 Protocol Byte  | Protocol Name | Description
@@ -69,19 +69,26 @@ Protocol Byte  | Protocol Name | Description
 
 NOTE: new message protocols will be defined here as new protocols become necessary. Please send a pull request if you'd like to suggest other protocols!
 
-### Message Type
+## Message Types
 In general, a `messageType` will be similar to a `messageProtocol`. It will also be a `byte` value and will be the **second byte** in the ioFog message content field. The type will serve to further specify how to decode the incoming message content or further specify what action a container should take when receiving a message.
 
 The message types for each message protocol are defined below:
 
+
+### Configuration Message Types
 Protocol Byte  | Type Byte | Protobuf Enum | Description
 ------------- | ------------- | ------------- | -------------
-`000`  | `-` | not defined | -
 `001`  | `000` | `UPDATE_ALERT` | informs the receiver that new configs are available. The receiver is expected to update their own configs.
 `001`  | `001` | `TRACK_CONFIG_SUBMISSION` | informs the receiver that a new track config is contained in this message and that the receiver should parse and persist the new track config. The `track-manager` is the intended consumer of this message type. **NOTE:** this config will be accepted as the new config by the track manager. This means changes will not be 'merged' with current configs. Use this message type when you want to submit a completely new config. Use other message types to update individual pieces of a track's configuration.
 `001`  | `002` | `TRACK_METADATA_SUBMISSION` | this message contains a TrackMetadata protobuf byte array and commands the receiver to update a track's metadata.
 `001`  | `003` | `MQTT_CONFIG_SUBMISSION` | this message contains an MqttConfig protobuf byte array and commands the receiver to update a track's MQTT configuration.
 `001`  | `004` | `OPC_CONFIG_SUBMISSION` | this message contains an OpcConfig protobuf byte array and commands the receiver to update a track's OPC configuration.
+`001`  | `005` | `OPC_SUBSCRIPTIONS_SUBMISSION` | this message contains an OpcConfig.subs value (OpcConfig.Subscriptions protobuf message) and commands the receiver to u pdate a track's OPC configuration subscriptions value.
+
+
+### Data Message Types
+Protocol Byte  | Type Byte | Protobuf Enum | Description
+------------- | ------------- | ------------- | -------------
 `002`  | `000` | `JSON` | used to define a message that is a protobuf byte array that will decode into a JSON string that will need to be parsed by the receiver.
 `002`  | `001` | `MQTT` | used to define a message that is a protobuf byte array that will decode into an MQTT message. This message contains everything necessary for the `mqtt-client` to send this message in MQTT format.
 `002`  | `002` | `OPC` | used to define a message that is a protobuf byte array that will decode into an OPC message. This message contains everything necessary for the `opc-client` to send this message in OPC format.

--- a/applications/opc-tag-filter/src/main/scala/com/hashmapinc/tempus/edge/opcTagFilter/Driver.scala
+++ b/applications/opc-tag-filter/src/main/scala/com/hashmapinc/tempus/edge/opcTagFilter/Driver.scala
@@ -21,9 +21,11 @@ object Driver {
     log.info("SELFNAME = " + System.getenv("SELFNAME"))
     log.info("CONTAINERID = " + Config.CONTAINER_ID)
 
-    Config.updateConfigs                // load initial configs.
-    OpcConnection.updateClient          // init client connection.
-    OpcController.updateSubscriptions   // look for subscriptions.
+    Config.updateConfigs                  // load initial configs.
+    if (Config.trackConfig.isDefined) {
+      OpcConnection.updateClient          // init client connection.
+      OpcController.updateSubscriptions   // look for subscriptions.
+    }
       
     log.info("Connecting to iofog...")
     IofogConnection.connect

--- a/protobuf-definitions/src/main/protobuf/MessageTypes.proto
+++ b/protobuf-definitions/src/main/protobuf/MessageTypes.proto
@@ -7,12 +7,12 @@ package com.hashmapinc.tempus.edge.proto;
 //=============================================================================
 // Define config message types
 enum ConfigMessageTypes {
-  UPDATE_ALERT = 0;               // alerts a container that new configs are available
-  TRACK_CONFIG_SUBMISSION = 1;    // submits a new track config to a container
-  TRACK_METADATA_SUBMISSION = 2;  // submits new track metadata to a container
-  MQTT_CONFIG_SUBMISSION = 3;     // submits new mqtt configs to a container
-  OPC_CONFIG_SUBMISSION = 4;      // submits new opc configs to a container
-  OPC_SUBSCRIPTIONS_SUBMISSION = 5;      // submits new opc subscriptions to a container
+  UPDATE_ALERT = 0;                   // alerts a container that new configs are available
+  TRACK_CONFIG_SUBMISSION = 1;        // submits a new track config to a container
+  TRACK_METADATA_SUBMISSION = 2;      // submits new track metadata to a container
+  MQTT_CONFIG_SUBMISSION = 3;         // submits new mqtt configs to a container
+  OPC_CONFIG_SUBMISSION = 4;          // submits new opc configs to a container
+  OPC_SUBSCRIPTIONS_SUBMISSION = 5;   // submits new opc subscriptions to a container
 }
 
 // Define data message types

--- a/protobuf-definitions/src/main/protobuf/OpcConfig.proto
+++ b/protobuf-definitions/src/main/protobuf/OpcConfig.proto
@@ -20,7 +20,11 @@ message OpcConfig {
   TagFilters tag_filters = 3;
 
   // define root from which to start BFS searching of tags
-  string tag_root = 4;
+  message TagRoot {
+    int32 namespace = 1;
+    string name = 2;
+  }
+  TagRoot tag_root = 4;
 
   // define device mapping regex's (regex -> device)
   message DeviceMap {

--- a/protobuf-definitions/src/main/protobuf/OpcConfig.proto
+++ b/protobuf-definitions/src/main/protobuf/OpcConfig.proto
@@ -19,12 +19,15 @@ message OpcConfig {
   }
   TagFilters tag_filters = 3;
 
+  // define root from which to start BFS searching of tags
+  string tag_root = 4;
+
   // define device mapping regex's (regex -> device)
   message DeviceMap {
     string pattern = 1;
     string device = 2;
   }
-  repeated DeviceMap device_maps = 4;
+  repeated DeviceMap device_maps = 5;
 
   // define subscriptions
   message Subscriptions {
@@ -34,5 +37,5 @@ message OpcConfig {
     }
     repeated Subscription list = 1;
   }
-  Subscriptions subs = 5;
+  Subscriptions subs = 6;
 }

--- a/protobuf-definitions/src/main/protobuf/OpcConfig.proto
+++ b/protobuf-definitions/src/main/protobuf/OpcConfig.proto
@@ -19,27 +19,27 @@ message OpcConfig {
   }
   TagFilters tag_filters = 3;
 
-  // define root from which to start BFS searching of tags
-  message TagRoot {
-    int32 namespace = 1;
-    string name = 2;
+  // Define an OPC Node
+  message OpcNode {
+    int32   namespace = 1;
+    string  id = 2;
   }
-  TagRoot tag_root = 4;
+  OpcNode tag_root = 4; // root from which to start BFS searching of tags
 
   // define device mapping regex's (regex -> device)
   message DeviceMap {
     string pattern = 1;
-    string device = 2;
+    string device_name = 2;
   }
   repeated DeviceMap device_maps = 5;
 
   // define subscriptions
   message Subscriptions {
     message Subscription {
-      string tag = 1;
-      string device = 2;
+      OpcNode node = 1;
+      string  device_name = 2;
     }
-    repeated Subscription list = 1;
+    repeated Subscription nodes = 1;
   }
   Subscriptions subs = 6;
 }


### PR DESCRIPTION
This PR contains updates to the OpcConfig protobuf definition and logic in the opc-tag-filter edge application to perform breadth first traversal of an opc server from a user-specified root node.