### PR TITLE
Added security to opcTagFilter

### DIFF
--- a/applications/opc-tag-filter/pom.xml
+++ b/applications/opc-tag-filter/pom.xml
@@ -46,6 +46,16 @@
       <artifactId>container-java-sdk</artifactId>
       <version>1.1.3</version>
     </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcprov-jdk15on</artifactId>
+      <version>1.58</version>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk15on</artifactId>
+      <version>1.58</version>
+    </dependency>
 
     <!-- Test -->
     <dependency>

--- a/applications/opc-tag-filter/src/main/scala/com/hashmapinc/tempus/edge/opcTagFilter/Config.scala
+++ b/applications/opc-tag-filter/src/main/scala/com/hashmapinc/tempus/edge/opcTagFilter/Config.scala
@@ -25,6 +25,9 @@ object Config {
   val OPC_RECONN_DELAY = 10000L   // 10 seconds between reconnection attempts
   val OPC_RECONN_MAX_ATTEMPTS = 5 // maximum of 5 reconnection attempts
 
+  // Path to local certificate
+  val CERTIFICATE_PATH = "./clientCert.der" // TODO: Change this
+
   /**
    * This function updates the trackConfig
    */

--- a/applications/opc-tag-filter/src/main/scala/com/hashmapinc/tempus/edge/opcTagFilter/Config.scala
+++ b/applications/opc-tag-filter/src/main/scala/com/hashmapinc/tempus/edge/opcTagFilter/Config.scala
@@ -31,7 +31,9 @@ object Config {
     log.info("Attempting load of trackConfig from " + PATH_TO_TRACK_CONFIG)
 
     // update configs
-    trackConfig = loadConfigs(PATH_TO_TRACK_CONFIG)
+    this synchronized {
+      trackConfig = loadConfigs(PATH_TO_TRACK_CONFIG)
+    }
   }
 
   /**

--- a/applications/opc-tag-filter/src/main/scala/com/hashmapinc/tempus/edge/opcTagFilter/Config.scala
+++ b/applications/opc-tag-filter/src/main/scala/com/hashmapinc/tempus/edge/opcTagFilter/Config.scala
@@ -22,7 +22,8 @@ object Config {
   val CONTAINER_ID = if(selfname == null) "" else selfname
 
   // OPC reconnection delay
-  val OPC_RECONN_DELAY = 10000L // 10 seconds between reconnection attempts
+  val OPC_RECONN_DELAY = 10000L   // 10 seconds between reconnection attempts
+  val OPC_RECONN_MAX_ATTEMPTS = 5 // maximum of 5 reconnection attempts
 
   /**
    * This function updates the trackConfig

--- a/applications/opc-tag-filter/src/main/scala/com/hashmapinc/tempus/edge/opcTagFilter/opc/OpcConnection.scala
+++ b/applications/opc-tag-filter/src/main/scala/com/hashmapinc/tempus/edge/opcTagFilter/opc/OpcConnection.scala
@@ -1,6 +1,5 @@
 package com.hashmapinc.tempus.edge.opcTagFilter.opc
 
-import java.io.File
 import scala.util.Try
 
 import org.eclipse.milo.opcua.sdk.client.OpcUaClient
@@ -52,8 +51,9 @@ object OpcConnection {
       }
     }).get.filter(_.getSecurityPolicyUri == securityPolicy.getSecurityPolicyUri)
 
+    // TODO: Filter for securityMode as well
     // get endpoint from filtered endpoints
-    val endpoint = Try(endpoints(0))
+    val endpoint = Try(endpoints(1))
     if (endpoint.isSuccess) 
       log.info("Using endpoint: {} [{}]", endpoint.get.getEndpointUrl(), securityPolicy)
     else {

--- a/applications/opc-tag-filter/src/main/scala/com/hashmapinc/tempus/edge/opcTagFilter/opc/OpcConnection.scala
+++ b/applications/opc-tag-filter/src/main/scala/com/hashmapinc/tempus/edge/opcTagFilter/opc/OpcConnection.scala
@@ -127,7 +127,7 @@ object OpcConnection {
       if (opcConf.isFailure || opcConf.get.endpoint.isEmpty)
         log.error("Could not update OPC client: no suitable OPC Configuration found. Will retry when new configs arrive.")
       else {
-        val client = recursiveUpdateClient(Try(createOpcClient(opcConf.get)), Config.OPC_RECONN_MAX_ATTEMPTS).toOption
+        client = recursiveUpdateClient(Try(createOpcClient(opcConf.get)), Config.OPC_RECONN_MAX_ATTEMPTS).toOption
         if (client.isDefined)
           log.info("OPC client successfully updated!")
         else 

--- a/applications/opc-tag-filter/src/main/scala/com/hashmapinc/tempus/edge/opcTagFilter/opc/OpcConnection.scala
+++ b/applications/opc-tag-filter/src/main/scala/com/hashmapinc/tempus/edge/opcTagFilter/opc/OpcConnection.scala
@@ -6,7 +6,6 @@ import org.eclipse.milo.opcua.sdk.client.OpcUaClient
 import org.eclipse.milo.opcua.sdk.client.api.config.{OpcUaClientConfig, OpcUaClientConfigBuilder}
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint
-import org.eclipse.milo.opcua.stack.core.types.enumerated.MessageSecurityMode
 import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription
 import org.eclipse.milo.opcua.stack.client.UaTcpStackClient
 import com.typesafe.scalalogging.Logger
@@ -37,8 +36,9 @@ object OpcConnection {
     //=========================================================================
     // setup endpoint
     //=========================================================================
-    val securityPolicy = OpcSecurity.getSecurityPolicy(opcConf)
-    val opcEndpoint = opcConf.endpoint   
+    val securityPolicy  = OpcSecurity.getSecurityPolicy(opcConf)
+    val securityMode    = OpcSecurity.getSecurityMode(opcConf)
+    val opcEndpoint     = opcConf.endpoint   
 
     // get all endpoints available at opcEndpoint that match the securityPolicy
     val endpoints = Try({
@@ -52,7 +52,7 @@ object OpcConnection {
       }
     }).get.filter( endpoint =>
       endpoint.getSecurityPolicyUri == securityPolicy.getSecurityPolicyUri 
-      && endpoint.getSecurityMode == MessageSecurityMode.SignAndEncrypt
+      && endpoint.getSecurityMode   == securityMode
     )
 
     // get endpoint from filtered endpoints

--- a/applications/opc-tag-filter/src/main/scala/com/hashmapinc/tempus/edge/opcTagFilter/opc/OpcConnection.scala
+++ b/applications/opc-tag-filter/src/main/scala/com/hashmapinc/tempus/edge/opcTagFilter/opc/OpcConnection.scala
@@ -6,6 +6,7 @@ import org.eclipse.milo.opcua.sdk.client.OpcUaClient
 import org.eclipse.milo.opcua.sdk.client.api.config.{OpcUaClientConfig, OpcUaClientConfigBuilder}
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint
+import org.eclipse.milo.opcua.stack.core.types.enumerated.MessageSecurityMode
 import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription
 import org.eclipse.milo.opcua.stack.client.UaTcpStackClient
 import com.typesafe.scalalogging.Logger
@@ -49,11 +50,13 @@ object OpcConnection {
         log.info("Trying explicit discovery URL: {}", discoveryUrl)
         UaTcpStackClient.getEndpoints(discoveryUrl).get
       }
-    }).get.filter(_.getSecurityPolicyUri == securityPolicy.getSecurityPolicyUri)
+    }).get.filter( endpoint =>
+      endpoint.getSecurityPolicyUri == securityPolicy.getSecurityPolicyUri 
+      && endpoint.getSecurityMode == MessageSecurityMode.SignAndEncrypt
+    )
 
-    // TODO: Filter for securityMode as well
     // get endpoint from filtered endpoints
-    val endpoint = Try(endpoints(1))
+    val endpoint = Try(endpoints(0))
     if (endpoint.isSuccess) 
       log.info("Using endpoint: {} [{}]", endpoint.get.getEndpointUrl(), securityPolicy)
     else {

--- a/applications/opc-tag-filter/src/main/scala/com/hashmapinc/tempus/edge/opcTagFilter/opc/OpcSecurity.scala
+++ b/applications/opc-tag-filter/src/main/scala/com/hashmapinc/tempus/edge/opcTagFilter/opc/OpcSecurity.scala
@@ -1,0 +1,45 @@
+package com.hashmapinc.tempus.edge.opcTagFilter.opc
+
+import java.io.File
+import scala.util.Try
+
+import com.typesafe.scalalogging.Logger
+import org.eclipse.milo.opcua.sdk.client.api.identity.AnonymousProvider
+import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy
+
+import com.hashmapinc.tempus.edge.proto.OpcConfig
+
+object OpcSecurity {
+  private val log = Logger(getClass())
+  
+  /**
+   * Creates a opcUaClient configuration
+   *
+   * @param opcConf - OpcConfig proto object with opc configuration to use
+   *
+   * @return securityPolicy - SecurityPolicy created from opcConf
+   */
+  def getSecurityPolicy (
+    opcConf: OpcConfig
+  ): SecurityPolicy = {
+    log.info("creating opc client configuration...")
+    
+    //=========================================================================
+    // security configs
+    //=========================================================================
+    val securityTempDir = new File(System.getProperty("java.io.tmpdir"), "security")
+    if (!securityTempDir.exists() && !securityTempDir.mkdirs()) {
+      throw new Exception("unable to create security dir: " + securityTempDir)
+    }
+    log.info("security temp dir: {}", securityTempDir.getAbsolutePath())
+
+    // TODO: Implement other securityPolicy options
+    val securityPolicy = 
+      if (opcConf.securityType == OpcConfig.SecurityType.NONE) SecurityPolicy.None
+      else {
+        SecurityPolicy.None
+      }
+    
+    securityPolicy
+  }
+}

--- a/applications/opc-tag-filter/src/main/scala/com/hashmapinc/tempus/edge/opcTagFilter/opc/OpcSecurity.scala
+++ b/applications/opc-tag-filter/src/main/scala/com/hashmapinc/tempus/edge/opcTagFilter/opc/OpcSecurity.scala
@@ -8,6 +8,7 @@ import scala.util.Try
 import com.typesafe.scalalogging.Logger
 import org.eclipse.milo.opcua.sdk.client.api.identity.{IdentityProvider, AnonymousProvider}
 import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy
+import org.eclipse.milo.opcua.stack.core.types.enumerated.MessageSecurityMode
 import org.eclipse.milo.opcua.stack.core.util.CryptoRestrictions
 import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateBuilder
 import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateGenerator
@@ -55,7 +56,32 @@ object OpcSecurity {
   }
 
   /**
-   * Creates a opcUaClient configuration
+   * Creates a securityMode from opcConf
+   *
+   * @param opcConf - OpcConfig proto object with opc configuration to use
+   *
+   * @return MessageSecurityMode - MessageSecurityMode created from opcConf
+   */
+  def getSecurityMode (
+    opcConf: OpcConfig
+  ): MessageSecurityMode = {
+    log.info("Getting OPC security mode...")
+
+    // Create security mode based on opcConf
+    opcConf.securityType match {
+      case OpcConfig.SecurityType.NONE            => MessageSecurityMode.None
+      case OpcConfig.SecurityType.BASIC128RSA15   => MessageSecurityMode.SignAndEncrypt
+      case OpcConfig.SecurityType.BASIC256        => MessageSecurityMode.SignAndEncrypt
+      case OpcConfig.SecurityType.BASIC256SHA256  => MessageSecurityMode.SignAndEncrypt
+      case _ => {
+        log.warn("Could not parse OpcConfig Security Mode from Type: {}. MessageSecurityMode.None will be used.", opcConf.securityType)
+        MessageSecurityMode.None
+      }
+    }
+  }
+
+  /**
+   * Creates an identity provider from opcConf
    *
    * @param opcConf - OpcConfig proto object with opc configuration to use
    *
@@ -69,7 +95,7 @@ object OpcSecurity {
   }
 
   /**
-   * Creates a client key pair
+   * Loads a client key pair
    *
    * @param opcConf - OpcConfig proto object with opc configuration to use
    *
@@ -84,7 +110,7 @@ object OpcSecurity {
   }
 
   /**
-   * Creates an X509Certificate
+   * Loads an X509Certificate
    *
    * @param opcConf - OpcConfig proto object with opc configuration to use
    *
@@ -94,7 +120,6 @@ object OpcSecurity {
     opcConf: OpcConfig
   ): X509Certificate = {
     log.info("Getting OPC client certificate...")
-
     // TODO: Load from keystore
     /**
     log.info("Attempting client certificate load from {}", Config.CERTIFICATE_PATH)

--- a/applications/opc-tag-filter/src/main/scala/com/hashmapinc/tempus/edge/opcTagFilter/opc/OpcSecurity.scala
+++ b/applications/opc-tag-filter/src/main/scala/com/hashmapinc/tempus/edge/opcTagFilter/opc/OpcSecurity.scala
@@ -1,16 +1,22 @@
 package com.hashmapinc.tempus.edge.opcTagFilter.opc
 
-import java.io.File
+import java.security.{KeyPair, KeyPairGenerator}
+import java.security.cert.X509Certificate
 import scala.util.Try
 
 import com.typesafe.scalalogging.Logger
-import org.eclipse.milo.opcua.sdk.client.api.identity.AnonymousProvider
+import org.eclipse.milo.opcua.sdk.client.api.identity.{IdentityProvider, AnonymousProvider}
 import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy
+import org.eclipse.milo.opcua.stack.core.util.CryptoRestrictions
+import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateBuilder
+import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateGenerator
 
 import com.hashmapinc.tempus.edge.proto.OpcConfig
 
 object OpcSecurity {
   private val log = Logger(getClass())
+
+  CryptoRestrictions.remove
   
   /**
    * Creates a opcUaClient configuration
@@ -22,24 +28,72 @@ object OpcSecurity {
   def getSecurityPolicy (
     opcConf: OpcConfig
   ): SecurityPolicy = {
-    log.info("creating opc client configuration...")
-    
-    //=========================================================================
-    // security configs
-    //=========================================================================
-    val securityTempDir = new File(System.getProperty("java.io.tmpdir"), "security")
-    if (!securityTempDir.exists() && !securityTempDir.mkdirs()) {
-      throw new Exception("unable to create security dir: " + securityTempDir)
-    }
-    log.info("security temp dir: {}", securityTempDir.getAbsolutePath())
+    log.info("Getting OPC security policy...")
 
-    // TODO: Implement other securityPolicy options
-    val securityPolicy = 
-      if (opcConf.securityType == OpcConfig.SecurityType.NONE) SecurityPolicy.None
-      else {
+    // Create security policy based on opcConf
+    opcConf.securityType match {
+      case OpcConfig.SecurityType.NONE            => SecurityPolicy.None
+      case OpcConfig.SecurityType.BASIC128RSA15   => SecurityPolicy.Basic128Rsa15
+      case OpcConfig.SecurityType.BASIC256        => SecurityPolicy.Basic256
+      case OpcConfig.SecurityType.BASIC256SHA256  => SecurityPolicy.Basic256Sha256
+      case _ => {
+        log.warn("Could not parse OpcConfig Security Type: {}. NONE will be used.", opcConf.securityType)
         SecurityPolicy.None
       }
-    
-    securityPolicy
+    }
+  }
+
+  /**
+   * Creates a opcUaClient configuration
+   *
+   * @param opcConf - OpcConfig proto object with opc configuration to use
+   *
+   * @return IdentityProvider - IdentityProvider created from opcConf
+   */
+  def getIdentityProvider (
+    opcConf: OpcConfig
+  ): IdentityProvider = {
+    log.info("Getting OPC security policy...")
+    new AnonymousProvider()
+  }
+
+  /**
+   * Creates a client key pair
+   *
+   * @param opcConf - OpcConfig proto object with opc configuration to use
+   *
+   * @return KeyPair - KeyPair created from opcConf
+   */
+  def getClientKeyPair (
+    opcConf: OpcConfig
+  ): KeyPair = {
+    log.info("Getting OPC client key pair...")
+    val kpg = KeyPairGenerator.getInstance("RSA")
+    kpg.initialize(2048)
+    kpg.genKeyPair
+  }
+
+  /**
+   * Creates an X509Certificate
+   *
+   * @param opcConf - OpcConfig proto object with opc configuration to use
+   *
+   * @return X509Certificate - X509Certificate created from opcConf
+   */
+  def getClientCertificate (
+    opcConf: OpcConfig
+  ): X509Certificate = {
+    log.info("Getting OPC client certificate...")
+    val keyPair = getClientKeyPair(opcConf)
+
+    new SelfSignedCertificateBuilder(keyPair)
+      .setCommonName("Tempus Edge - OPC Tag Filter Client")
+      .setOrganization("hashmapinc")
+      .setOrganizationalUnit("tempus edge")
+      .setLocalityName("Atlanta")
+      .setStateName("GA")
+      .setCountryCode("US")
+      .setApplicationUri("urn:hashmapinc:tempus:edge:opc-client")
+      .build
   }
 }

--- a/protobuf-definitions/src/main/protobuf/OpcConfig.proto
+++ b/protobuf-definitions/src/main/protobuf/OpcConfig.proto
@@ -9,6 +9,9 @@ message OpcConfig {
   // define available security types
   enum SecurityType {
     NONE = 0;
+    BASIC128RSA15 = 1;
+    BASIC256 = 2;
+    BASIC256SHA256 = 3;
   }
   SecurityType security_type = 2; // security settings to use
 
@@ -45,4 +48,8 @@ message OpcConfig {
 
   // define subscription monitoring frequency
   uint32 subs_update_freq = 7;
+
+  // define identity
+  string client_identity = 8;
+  string client_password = 9;
 }


### PR DESCRIPTION
This PR includes logic to support NONE, BASIC256, BASIC128RSA15, and BASIC256SHA256 security types in opc-tag-filter.

opc-tag-filter will currently generate its own keypair and its own signed x509 cert at run time, but this functionality will be replaced with a provisioning process for real-world deployments