### PR TITLE
Added identity provider support to opc-tag-filter

### DIFF
--- a/applications/opc-tag-filter/src/main/scala/com/hashmapinc/tempus/edge/opcTagFilter/opc/OpcConnection.scala
+++ b/applications/opc-tag-filter/src/main/scala/com/hashmapinc/tempus/edge/opcTagFilter/opc/OpcConnection.scala
@@ -67,10 +67,10 @@ object OpcConnection {
 
     // return config
     OpcUaClientConfig.builder()
-      .setApplicationName(LocalizedText.english("hashmapinc tempus edge opc client"))
-      .setApplicationUri("urn:hashmapinc:tempus:edge:opc-client")
-      .setCertificate(OpcSecurity.getClientCertificate(opcConf))
-      .setKeyPair(OpcSecurity.getClientKeyPair(opcConf))
+      .setApplicationName(LocalizedText.english("hashmapinc tempus edge opc tag filter"))
+      .setApplicationUri("urn:hashmapinc:tempus:edge:opc-tag-filter")
+      .setCertificate(OpcSecurity.clientCertificate)
+      .setKeyPair(OpcSecurity.clientKeyPair)
       .setEndpoint(endpoint.get)
       .setIdentityProvider(OpcSecurity.getIdentityProvider(opcConf))
       .setRequestTimeout(uint(5000))

--- a/applications/opc-tag-filter/src/main/scala/com/hashmapinc/tempus/edge/opcTagFilter/opc/OpcSecurity.scala
+++ b/applications/opc-tag-filter/src/main/scala/com/hashmapinc/tempus/edge/opcTagFilter/opc/OpcSecurity.scala
@@ -6,7 +6,7 @@ import java.security.cert.{X509Certificate, CertificateFactory}
 import scala.util.Try
 
 import com.typesafe.scalalogging.Logger
-import org.eclipse.milo.opcua.sdk.client.api.identity.{IdentityProvider, AnonymousProvider}
+import org.eclipse.milo.opcua.sdk.client.api.identity.{IdentityProvider, AnonymousProvider, UsernameProvider}
 import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy
 import org.eclipse.milo.opcua.stack.core.types.enumerated.MessageSecurityMode
 import org.eclipse.milo.opcua.stack.core.util.CryptoRestrictions
@@ -93,6 +93,10 @@ object OpcSecurity {
     opcConf: OpcConfig
   ): IdentityProvider = {
     log.info("Getting OPC security policy...")
-    new AnonymousProvider()
+
+    opcConf.clientIdentity match {
+      case "" => new AnonymousProvider() // no id provided, connect anonymously
+      case _  => new UsernameProvider(opcConf.clientIdentity, opcConf.clientPassword)
+    }
   }
 }

--- a/applications/opc-tag-filter/src/main/scala/com/hashmapinc/tempus/edge/opcTagFilter/opc/OpcSecurity.scala
+++ b/applications/opc-tag-filter/src/main/scala/com/hashmapinc/tempus/edge/opcTagFilter/opc/OpcSecurity.scala
@@ -19,15 +19,17 @@ import com.hashmapinc.tempus.edge.opcTagFilter.Config
 object OpcSecurity {
   private val log = Logger(getClass())
 
+  // TODO: Replace this with java keystore logic at some point or maybe some kind of privisioning logic
+  // Generate keypair and certificate at run time
   val clientKeyPair = SelfSignedCertificateGenerator.generateRsaKeyPair(2048)
-  val certificate = (new SelfSignedCertificateBuilder(clientKeyPair)
+  val clientCertificate = (new SelfSignedCertificateBuilder(clientKeyPair)
     .setCommonName("Tempus Edge OPC Tag Filter")
     .setOrganization("hashmapinc")
     .setOrganizationalUnit("tempus edge")
     .setLocalityName("Atlanta")
     .setStateName("GA")
     .setCountryCode("US")
-    .setApplicationUri("urn:hashmapinc:tempus:edge:opc-client")
+    .setApplicationUri("urn:hashmapinc:tempus:edge:opc-tag-filter")
   ).build
   
   /**
@@ -92,44 +94,5 @@ object OpcSecurity {
   ): IdentityProvider = {
     log.info("Getting OPC security policy...")
     new AnonymousProvider()
-  }
-
-  /**
-   * Loads a client key pair
-   *
-   * @param opcConf - OpcConfig proto object with opc configuration to use
-   *
-   * @return KeyPair - KeyPair created from opcConf
-   */
-  def getClientKeyPair (
-    opcConf: OpcConfig
-  ): KeyPair = {
-    log.info("Getting OPC client key pair...")
-    // TODO: Load from keystore
-    clientKeyPair
-  }
-
-  /**
-   * Loads an X509Certificate
-   *
-   * @param opcConf - OpcConfig proto object with opc configuration to use
-   *
-   * @return X509Certificate - X509Certificate created from opcConf
-   */
-  def getClientCertificate (
-    opcConf: OpcConfig
-  ): X509Certificate = {
-    log.info("Getting OPC client certificate...")
-    // TODO: Load from keystore
-    /**
-    log.info("Attempting client certificate load from {}", Config.CERTIFICATE_PATH)
-    
-    val certInputStream = new FileInputStream(Config.CERTIFICATE_PATH)
-    CertificateFactory
-      .getInstance("X.509")
-      .generateCertificate(certInputStream)
-      .asInstanceOf[X509Certificate]
-    */
-    certificate
   }
 }


### PR DESCRIPTION
This PR includes logic to search OpcConfig from track-manager for clientIdentity and clientPassword credentials to incorporate into a milo opc UA client configuration. This is fully supported by all current security types as well.