### PR TITLE
Added security support to opc-client

### DIFF
--- a/applications/opc-client/pom.xml
+++ b/applications/opc-client/pom.xml
@@ -46,6 +46,16 @@
       <artifactId>container-java-sdk</artifactId>
       <version>1.1.3</version>
     </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcprov-jdk15on</artifactId>
+      <version>1.58</version>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk15on</artifactId>
+      <version>1.58</version>
+    </dependency>
 
     <!-- Test -->
     <dependency>

--- a/applications/opc-client/src/main/scala/com/hashmapinc/tempus/edge/opcClient/Config.scala
+++ b/applications/opc-client/src/main/scala/com/hashmapinc/tempus/edge/opcClient/Config.scala
@@ -23,6 +23,7 @@ object Config {
 
   // OPC settings
   val OPC_RECONN_DELAY    = 10000L // 10 seconds between reconnection attempts
+  val OPC_RECONN_MAX_ATTEMPTS = 5 // maximum of 5 reconnection attempts
   val DEFAULT_UPDATE_FREQ = 10000L // 10 seconds between subscription polling
 
   /**
@@ -32,7 +33,9 @@ object Config {
     log.info("Attempting load of trackConfig from " + PATH_TO_TRACK_CONFIG)
 
     // update configs
-    trackConfig = loadConfigs(PATH_TO_TRACK_CONFIG)
+    this synchronized {
+      trackConfig = loadConfigs(PATH_TO_TRACK_CONFIG)
+    }
   }
 
   /**

--- a/applications/opc-client/src/main/scala/com/hashmapinc/tempus/edge/opcClient/opc/OpcConnection.scala
+++ b/applications/opc-client/src/main/scala/com/hashmapinc/tempus/edge/opcClient/opc/OpcConnection.scala
@@ -1,4 +1,4 @@
-package com.hashmapinc.tempus.edge.opcTagFilter.opc
+package com.hashmapinc.tempus.edge.opcClient.opc
 
 import scala.util.Try
 
@@ -10,7 +10,7 @@ import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription
 import org.eclipse.milo.opcua.stack.client.UaTcpStackClient
 import com.typesafe.scalalogging.Logger
 
-import com.hashmapinc.tempus.edge.opcTagFilter.Config
+import com.hashmapinc.tempus.edge.opcClient.Config
 import com.hashmapinc.tempus.edge.proto.OpcConfig
 
 object OpcConnection {

--- a/applications/opc-client/src/main/scala/com/hashmapinc/tempus/edge/opcClient/opc/OpcConnection.scala
+++ b/applications/opc-client/src/main/scala/com/hashmapinc/tempus/edge/opcClient/opc/OpcConnection.scala
@@ -67,8 +67,8 @@ object OpcConnection {
 
     // return config
     OpcUaClientConfig.builder()
-      .setApplicationName(LocalizedText.english("hashmapinc tempus edge opc tag filter"))
-      .setApplicationUri("urn:hashmapinc:tempus:edge:opc-tag-filter")
+      .setApplicationName(LocalizedText.english("Hashmapinc Tempus Edge OPC Client"))
+      .setApplicationUri("urn:hashmapinc:tempus:edge:opc-client")
       .setCertificate(OpcSecurity.clientCertificate)
       .setKeyPair(OpcSecurity.clientKeyPair)
       .setEndpoint(endpoint.get)

--- a/applications/opc-client/src/main/scala/com/hashmapinc/tempus/edge/opcClient/opc/OpcConnection.scala
+++ b/applications/opc-client/src/main/scala/com/hashmapinc/tempus/edge/opcClient/opc/OpcConnection.scala
@@ -1,63 +1,47 @@
-package com.hashmapinc.tempus.edge.opcClient.opc
+package com.hashmapinc.tempus.edge.opcTagFilter.opc
 
-import java.io.File
-import java.util.Arrays
 import scala.util.Try
 
 import org.eclipse.milo.opcua.sdk.client.OpcUaClient
 import org.eclipse.milo.opcua.sdk.client.api.config.{OpcUaClientConfig, OpcUaClientConfigBuilder}
-import org.eclipse.milo.opcua.sdk.client.api.identity.AnonymousProvider
-import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint
 import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription
 import org.eclipse.milo.opcua.stack.client.UaTcpStackClient
 import com.typesafe.scalalogging.Logger
 
-import com.hashmapinc.tempus.edge.opcClient.Config
+import com.hashmapinc.tempus.edge.opcTagFilter.Config
 import com.hashmapinc.tempus.edge.proto.OpcConfig
 
 object OpcConnection {
   private val log = Logger(getClass())
 
-  // OPC client
+  // create client
   var client: Option[OpcUaClient] = None
   
   /**
-   * Creates a opcUaClient configuration
+   *  Creates an opcUaClient configuration
    *
-   * @param opcEndpoint - String holding the opc endpoint to connect to
-   * @param securityType - SecurityType protobuf object describing the security to use
+   *  This function is not fault tolerant. The caller should handle errors.
+   *
+   *  @param opcConf           - OpcConfig proto object with opc configuration to use
+   *
+   *  @return opcClientConfig  - OpcUaClientConfig created from opcConf
    */
-  private def getClientConfig (
-    opcEndpoint: String,
-    securityType: OpcConfig.SecurityType
+  def getClientConfig (
+    opcConf: OpcConfig
   ): OpcUaClientConfig = {
     log.info("creating opc client configuration...")
-    
-    //=========================================================================
-    // security configs
-    //=========================================================================
-    val securityTempDir = new File(System.getProperty("java.io.tmpdir"), "security")
-    if (!securityTempDir.exists() && !securityTempDir.mkdirs()) {
-      throw new Exception("unable to create security dir: " + securityTempDir)
-    }
-    log.info("security temp dir: {}", securityTempDir.getAbsolutePath())
-
-    // TODO: Implement other securityPolicy options
-    val securityPolicy = 
-      if (securityType == OpcConfig.SecurityType.NONE) SecurityPolicy.None
-      else {
-        log.error("could not implement securityType: " + securityType)
-        throw new Exception("unable to implement securityType: " + securityType)
-      }
 
     //=========================================================================
+    // setup endpoint
+    //=========================================================================
+    val securityPolicy  = OpcSecurity.getSecurityPolicy(opcConf)
+    val securityMode    = OpcSecurity.getSecurityMode(opcConf)
+    val opcEndpoint     = opcConf.endpoint   
 
-    //=========================================================================
-    // endpoint configs
-    //=========================================================================
-    val endpoints= Try({
+    // get all endpoints available at opcEndpoint that match the securityPolicy
+    val endpoints = Try({
       UaTcpStackClient.getEndpoints(opcEndpoint).get
     }).recover({
       case e: Exception => {
@@ -66,21 +50,29 @@ object OpcConnection {
         log.info("Trying explicit discovery URL: {}", discoveryUrl)
         UaTcpStackClient.getEndpoints(discoveryUrl).get
       }
-    }).get
+    }).get.filter( endpoint =>
+      endpoint.getSecurityPolicyUri == securityPolicy.getSecurityPolicyUri 
+      && endpoint.getSecurityMode   == securityMode
+    )
 
-    val endpoint = Arrays.stream(endpoints).
-      filter(e => e.getSecurityPolicyUri().equals(securityPolicy.getSecurityPolicyUri())).
-      findFirst().orElseThrow(()=> new Exception("no desired endpoints returned"))
-
-    log.info("Using endpoint: {} [{}]", endpoint.getEndpointUrl(), securityPolicy)
+    // get endpoint from filtered endpoints
+    val endpoint = Try(endpoints(0))
+    if (endpoint.isSuccess) 
+      log.info("Using endpoint: {} [{}]", endpoint.get.getEndpointUrl(), securityPolicy)
+    else {
+      log.error("No endpoints with proper security policies were found for securityPolicy = {} at opcEndpoint = ", securityPolicy, opcEndpoint)
+      throw new Exception("Could not connect")
+    }
     //=========================================================================
 
     // return config
     OpcUaClientConfig.builder()
-      .setApplicationName(LocalizedText.english("hashmapinc tempus edge opc client"))
-      .setApplicationUri("urn:hashmapinc:tempus:edge:opc-client")
-      .setEndpoint(endpoint)
-      .setIdentityProvider(new AnonymousProvider())
+      .setApplicationName(LocalizedText.english("hashmapinc tempus edge opc tag filter"))
+      .setApplicationUri("urn:hashmapinc:tempus:edge:opc-tag-filter")
+      .setCertificate(OpcSecurity.clientCertificate)
+      .setKeyPair(OpcSecurity.clientKeyPair)
+      .setEndpoint(endpoint.get)
+      .setIdentityProvider(OpcSecurity.getIdentityProvider(opcConf))
       .setRequestTimeout(uint(5000))
       .build
   }
@@ -88,18 +80,36 @@ object OpcConnection {
   /**
    * Creates a new opc client.
    *
-   * @param opcEndpoint - String holding the opc endpoint to connect to
-   * @param securityType - SecurityType protobuf object describing the 
-   *                       security to use
+   * @param opcConf    - OpcConfig proto object with opc configuration to use
    *
    * @return opcClient - new opc client
    */
-  private def createOpcClient (
-    opcEndpoint: String,
-    securityType: OpcConfig.SecurityType
+  def createOpcClient (
+    opcConf: OpcConfig
   ): OpcUaClient = {
     log.info("creating new opc client..")
-    new OpcUaClient(getClientConfig(opcEndpoint, securityType))
+    new OpcUaClient(getClientConfig(opcConf))
+  }
+
+  /**
+   * recursion utility for retrying client updating
+   *
+   * @param updatedClient           - Try[OpcUaClient] from the previous caller
+   * @param remainingAttempts       - Int value of remaining retry attempts
+   *
+   * @return successfulUpdateClient - Try[OpcUaClient] result of updateClient attempt
+   */
+  @scala.annotation.tailrec
+  def recursiveUpdateClient(
+    updatedClient:      Try[OpcUaClient],
+    remainingAttempts:  Int
+  ): Try[OpcUaClient] = {
+    if (updatedClient.isSuccess || remainingAttempts < 1) updatedClient else {
+      log.error("Could not update OPC client. Received error: " + updatedClient.failed.get)
+      log.error("Will retry connection {} more time(s) in {} milliseconds...", remainingAttempts, Config.OPC_RECONN_DELAY)
+      Thread.sleep(Config.OPC_RECONN_DELAY)
+      recursiveUpdateClient(Try(createOpcClient(Config.trackConfig.get.getOpcConfig)), remainingAttempts - 1)
+    }
   }
 
   /**
@@ -107,7 +117,7 @@ object OpcConnection {
    *  opc configuration.
    *
    *  If client creation fails, updateClient will retry every 
-   *  Config.OPC_RECONN_DELAY mSeconds until it succeeds.
+   *  Config.OPC_RECONN_DELAY milliseconds until it succeeds.
    */
   def updateClient: Unit = {
     this.synchronized {
@@ -117,28 +127,18 @@ object OpcConnection {
         client.get.disconnect
       }
 
-      // get client configuration
-      val endpoint      = Try(Config.trackConfig.get.getOpcConfig.endpoint).getOrElse("")
-      val securityType  = Try(Config.trackConfig.get.getOpcConfig.securityType).getOrElse(OpcConfig.SecurityType.NONE)
+      // get latest local opcConfigs
+      val opcConf = Try(Config.trackConfig.get.getOpcConfig)
 
-      // create client
-      if (endpoint.isEmpty)
-        log.error("No OPC endpoint defined. Cannot create opc client. Will retry on new configuration.")
+      // if opcConfig exists and has an endpoint, let's connect!
+      if (opcConf.isFailure || opcConf.get.endpoint.isEmpty)
+        log.error("Could not update OPC client: no suitable OPC Configuration found. Will retry when new configs arrive.")
       else {
-        var updatedClient = Try(Option(createOpcClient(endpoint, securityType)))
-
-        while (updatedClient.isFailure) { // TODO: this feels not Scala-y. Find a way to do this elegantly
-          log.error("unable to update opc client. Will retry in {} milliseconds...", Config.OPC_RECONN_DELAY)
-          Thread.sleep(Config.OPC_RECONN_DELAY)
-          updatedClient = Try({
-            val endpoint = Config.trackConfig.get.getOpcConfig.endpoint
-            val securityType = Config.trackConfig.get.getOpcConfig.securityType
-            Option(createOpcClient(endpoint, securityType))
-          })
-        }
-        
-        client = updatedClient.getOrElse(None)
-        log.info("Successfully updated client.")
+        client = recursiveUpdateClient(Try(createOpcClient(opcConf.get)), Config.OPC_RECONN_MAX_ATTEMPTS).toOption
+        if (client.isDefined)
+          log.info("OPC client successfully updated!")
+        else 
+          log.warn("OPC client update was unsuccessful. Will retry when new OPC configs arrive.")
       }
     }
   }

--- a/applications/opc-client/src/main/scala/com/hashmapinc/tempus/edge/opcClient/opc/OpcSecurity.scala
+++ b/applications/opc-client/src/main/scala/com/hashmapinc/tempus/edge/opcClient/opc/OpcSecurity.scala
@@ -23,13 +23,13 @@ object OpcSecurity {
   // Generate keypair and certificate at run time
   val clientKeyPair = SelfSignedCertificateGenerator.generateRsaKeyPair(2048)
   val clientCertificate = (new SelfSignedCertificateBuilder(clientKeyPair)
-    .setCommonName("Tempus Edge OPC Tag Filter")
+    .setCommonName("Tempus Edge OPC Client")
     .setOrganization("hashmapinc")
     .setOrganizationalUnit("tempus edge")
     .setLocalityName("Atlanta")
     .setStateName("GA")
     .setCountryCode("US")
-    .setApplicationUri("urn:hashmapinc:tempus:edge:opc-tag-filter")
+    .setApplicationUri("urn:hashmapinc:tempus:edge:opc-client")
   ).build
   
   /**

--- a/applications/opc-client/src/main/scala/com/hashmapinc/tempus/edge/opcClient/opc/OpcSecurity.scala
+++ b/applications/opc-client/src/main/scala/com/hashmapinc/tempus/edge/opcClient/opc/OpcSecurity.scala
@@ -1,0 +1,102 @@
+package com.hashmapinc.tempus.edge.opcClient.opc
+
+import java.io.FileInputStream
+import java.security.{KeyPair, KeyPairGenerator}
+import java.security.cert.{X509Certificate, CertificateFactory}
+import scala.util.Try
+
+import com.typesafe.scalalogging.Logger
+import org.eclipse.milo.opcua.sdk.client.api.identity.{IdentityProvider, AnonymousProvider, UsernameProvider}
+import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy
+import org.eclipse.milo.opcua.stack.core.types.enumerated.MessageSecurityMode
+import org.eclipse.milo.opcua.stack.core.util.CryptoRestrictions
+import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateBuilder
+import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateGenerator
+
+import com.hashmapinc.tempus.edge.proto.OpcConfig
+import com.hashmapinc.tempus.edge.opcClient.Config
+
+object OpcSecurity {
+  private val log = Logger(getClass())
+
+  // TODO: Replace this with java keystore logic at some point or maybe some kind of privisioning logic
+  // Generate keypair and certificate at run time
+  val clientKeyPair = SelfSignedCertificateGenerator.generateRsaKeyPair(2048)
+  val clientCertificate = (new SelfSignedCertificateBuilder(clientKeyPair)
+    .setCommonName("Tempus Edge OPC Tag Filter")
+    .setOrganization("hashmapinc")
+    .setOrganizationalUnit("tempus edge")
+    .setLocalityName("Atlanta")
+    .setStateName("GA")
+    .setCountryCode("US")
+    .setApplicationUri("urn:hashmapinc:tempus:edge:opc-tag-filter")
+  ).build
+  
+  /**
+   * Creates a opcUaClient configuration
+   *
+   * @param opcConf - OpcConfig proto object with opc configuration to use
+   *
+   * @return securityPolicy - SecurityPolicy created from opcConf
+   */
+  def getSecurityPolicy (
+    opcConf: OpcConfig
+  ): SecurityPolicy = {
+    log.info("Getting OPC security policy...")
+
+    // Create security policy based on opcConf
+    opcConf.securityType match {
+      case OpcConfig.SecurityType.NONE            => SecurityPolicy.None
+      case OpcConfig.SecurityType.BASIC128RSA15   => SecurityPolicy.Basic128Rsa15
+      case OpcConfig.SecurityType.BASIC256        => SecurityPolicy.Basic256
+      case OpcConfig.SecurityType.BASIC256SHA256  => SecurityPolicy.Basic256Sha256
+      case _ => {
+        log.warn("Could not parse OpcConfig Security Type: {}. NONE will be used.", opcConf.securityType)
+        SecurityPolicy.None
+      }
+    }
+  }
+
+  /**
+   * Creates a securityMode from opcConf
+   *
+   * @param opcConf - OpcConfig proto object with opc configuration to use
+   *
+   * @return MessageSecurityMode - MessageSecurityMode created from opcConf
+   */
+  def getSecurityMode (
+    opcConf: OpcConfig
+  ): MessageSecurityMode = {
+    log.info("Getting OPC security mode...")
+
+    // Create security mode based on opcConf
+    opcConf.securityType match {
+      case OpcConfig.SecurityType.NONE            => MessageSecurityMode.None
+      case OpcConfig.SecurityType.BASIC128RSA15   => MessageSecurityMode.SignAndEncrypt
+      case OpcConfig.SecurityType.BASIC256        => MessageSecurityMode.SignAndEncrypt
+      case OpcConfig.SecurityType.BASIC256SHA256  => MessageSecurityMode.SignAndEncrypt
+      case _ => {
+        log.warn("Could not parse OpcConfig Security Mode from Type: {}. MessageSecurityMode.None will be used.", opcConf.securityType)
+        MessageSecurityMode.None
+      }
+    }
+  }
+
+  /**
+   * Creates an identity provider from opcConf
+   *
+   * @param opcConf - OpcConfig proto object with opc configuration to use
+   *
+   * @return IdentityProvider - IdentityProvider created from opcConf
+   */
+  def getIdentityProvider (
+    opcConf: OpcConfig
+  ): IdentityProvider = {
+    log.info("Getting OPC security policy...")
+
+    opcConf.clientIdentity match {
+      case "" => new AnonymousProvider() // no id provided, connect anonymously
+      case _  => new UsernameProvider(opcConf.clientIdentity, opcConf.clientPassword)
+    }
+  }
+}

--- a/applications/opc-tag-filter/src/main/scala/com/hashmapinc/tempus/edge/opcTagFilter/Config.scala
+++ b/applications/opc-tag-filter/src/main/scala/com/hashmapinc/tempus/edge/opcTagFilter/Config.scala
@@ -25,9 +25,6 @@ object Config {
   val OPC_RECONN_DELAY = 10000L   // 10 seconds between reconnection attempts
   val OPC_RECONN_MAX_ATTEMPTS = 5 // maximum of 5 reconnection attempts
 
-  // Path to local certificate
-  val CERTIFICATE_PATH = "./clientCert.der" // TODO: Change this
-
   /**
    * This function updates the trackConfig
    */


### PR DESCRIPTION
This PR duplicates the security features from opc-tag-filter into opc-client. This includes:
- Support for 4 security types
- Support for 2 OPC message security modes
- Support for 2 OPC Identity Providers 
- Substantially improved reconnection logic and error handling throughout.