### PR TITLE
One-click building of all edge applications

### DIFF
--- a/applications/Makefile
+++ b/applications/Makefile
@@ -1,0 +1,76 @@
+# Define dirs
+CURR_DIR=$(shell pwd)
+JSON_TRANSLATOR=$(CURR_DIR)/json-translator
+MQTT_CLIENT_GO=$(CURR_DIR)/mqtt-client-go
+MQTT_CLIENT_PYTHON=$(CURR_DIR)/mqtt-client-python
+OPC_CLIENT=$(CURR_DIR)/opc-client
+OPC_TAG_FILTER=$(CURR_DIR)/opc-tag-filter
+TIMESERIES_GENERATOR=$(CURR_DIR)/timeseries-generator
+TRACK_MANAGER=$(CURR_DIR)/track-manager
+
+# define docker repo to deploy to
+DOCKER_REPO=hashmapinc
+
+all: build 
+
+
+print-spacer:
+	echo "\n\n\n\n\n"
+
+build:build-json-translator build-mqtt-client-go build-mqtt-client-python build-opc-client build-opc-tag-filter build-timeseries-generator build-track-manager
+
+
+build-json-translator: print-spacer
+	cd $(JSON_TRANSLATOR) && \
+	mvn clean package -q
+
+build-mqtt-client-go: print-spacer
+	cd $(MQTT_CLIENT_GO) && \
+	make clean docker
+
+build-mqtt-client-python: print-spacer
+	cd $(MQTT_CLIENT_PYTHON) && \
+	make build
+
+build-opc-client: print-spacer
+	cd $(OPC_CLIENT) && \
+	mvn clean package -q
+
+build-opc-tag-filter: print-spacer
+	cd $(OPC_TAG_FILTER) && \
+	mvn clean package -q
+
+build-timeseries-generator: print-spacer
+	cd $(TIMESERIES_GENERATOR) && \
+	echo "timeseries-generator building is trash and is not automated. See github issues if you want to fix this."
+
+build-track-manager: print-spacer
+	cd $(TRACK_MANAGER) && \
+	mvn clean package -q
+
+
+deploy:deploy-json-translator deploy-mqtt-client-go deploy-mqtt-client-python deploy-opc-client deploy-opc-tag-filter deploy-timeseries-generator deploy-track-manager
+
+
+deploy-json-translator: print-spacer
+	docker push $(DOCKER_REPO)/tempus-edge-json-translator
+
+deploy-mqtt-client-go: print-spacer
+	cd $(MQTT_CLIENT_GO) && \
+	make deploy
+
+deploy-mqtt-client-python: print-spacer
+	cd $(MQTT_CLIENT_PYTHON) && \
+	make deploy
+
+deploy-opc-client: print-spacer
+	docker push $(DOCKER_REPO)/tempus-edge-opc-client
+
+deploy-opc-tag-filter: print-spacer
+	docker push $(DOCKER_REPO)/tempus-edge-opc-tag-filter
+
+deploy-timeseries-generator: print-spacer
+	echo "timeseries-generator deployment is trash and is not automated. See github issues if you want to fix this."
+
+deploy-track-manager: print-spacer
+	docker push $(DOCKER_REPO)/tempus-edge-track-manager

--- a/applications/mqtt-client-go/.gitignore
+++ b/applications/mqtt-client-go/.gitignore
@@ -1,5 +1,5 @@
 # ignore the mqtt client executable
-mqtt-client?.?.?
+mqtt-client-go?.?.?
 
 # ignore sample configs
 config.pb

--- a/applications/mqtt-client-go/Makefile
+++ b/applications/mqtt-client-go/Makefile
@@ -1,5 +1,5 @@
 # Make parameters
-APP_NAME=mqtt-client
+APP_NAME=mqtt-client-go
 VERSION=0.1.0
 EXECUTABLE=$(APP_NAME)$(VERSION)
 TARGET_PACKAGE=com/hashmapinc/tempus/edge/mqtt/client/driver

--- a/applications/mqtt-client-python/Makefile
+++ b/applications/mqtt-client-python/Makefile
@@ -1,10 +1,10 @@
 all:build
 
 build:
-	docker build --no-cache -t hashmapinc/iofog:mqtt-client .
+	docker build --no-cache -t hashmapinc/tempus-edge-mqtt-client-python .
 run: build
-	docker run -it hashmapinc/iofog:mqtt-client
+	docker run -it hashmapinc/tempus-edge-mqtt-client-python
 shell: build
-	docker run -it hashmapinc/iofog:mqtt-client /bin/ash
+	docker run -it hashmapinc/tempus-edge-mqtt-client-python /bin/ash
 deploy: build
-	docker push hashmapinc/iofog:mqtt-client
+	docker push hashmapinc/tempus-edge-mqtt-client-python


### PR DESCRIPTION
This PR includes:
- Addition of Makefile in the applications/ directory for building and deploying all edge applications.
- finally reconciled the naming of the go and python versions of the mqtt client.